### PR TITLE
Code files,badges all are present in separate folders

### DIFF
--- a/app/generate-badges.py
+++ b/app/generate-badges.py
@@ -6,11 +6,13 @@ import itertools
 import shutil
 import html
 
-input_files = [file for file in os.listdir(".")
+APP_ROOT = os.path.dirname(os.path.abspath(__file__))
+UPLOAD_FOLDER = os.path.join(APP_ROOT, 'static/uploads')
+input_files = [file for file in os.listdir("./static/uploads")
                if file.lower().endswith(".csv")]
 
 NUMBER_OF_BADGES_PER_PAGE = 8
-with open("../../../badges/8BadgesOnA3.svg", encoding="UTF-8") as f:
+with open("../badges/8BadgesOnA3.svg", encoding="UTF-8") as f:
     CONTENT = f.read()
 
 def generate_badges(aggregate, folder, index, picture):
@@ -38,26 +40,27 @@ def generate_badges(aggregate, folder, index, picture):
 
 for input_file in input_files:
     picture = os.path.splitext(input_file)[0]
-    if not os.path.isfile(picture):
+    picpath='./static/uploads/'+picture
+    if not os.path.isfile(picpath):
         print("SKIP: {} has no picture {}".format(input_file, picture))
         continue
     print("READING: {}".format(input_file))
-    folder = input_file + ".badges"
+    folder = APP_ROOT+'/static/badges/'+input_file + ".badges"
     shutil.rmtree(folder, ignore_errors=True)
     try:
         os.makedirs(folder, exist_ok=True)
     except PermissionError:
         pass
     
-    with open(input_file, encoding="UTF-8") as f:
+    with open(os.path.join(UPLOAD_FOLDER, input_file), encoding="UTF-8") as f:
         aggregate = []
         i = 1
         for row in csv.reader(f):
             aggregate.append(row)
             aggregate.append(row)
             if len(aggregate) >= NUMBER_OF_BADGES_PER_PAGE:
-                generate_badges(aggregate, folder, i, picture)
+                generate_badges(aggregate, folder, i, picpath)
                 aggregate = []
                 i += 1
         if aggregate:
-            generate_badges(aggregate, folder, i, picture)
+            generate_badges(aggregate, folder, i, picpath)

--- a/app/main.py
+++ b/app/main.py
@@ -5,22 +5,29 @@ import os
 
 APP_ROOT = os.path.dirname(os.path.abspath(__file__))
 UPLOAD_FOLDER = os.path.join(APP_ROOT, 'static/uploads')
-
+SCRIPT=os.path.join(APP_ROOT, 'merge_badges.sh')
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024
 app.config['SECRET_KEY'] = 'secret'
 
+
 @app.route('/')
 def index():
-	return render_template('index.html')
+    return render_template('index.html')
+
 
 def generate_badges():
+<<<<<<< HEAD
+    os.system(SCRIPT)
+    
+=======
     os.system(os.path.join(app.config['UPLOAD_FOLDER'], 'merge_badges.sh'))
 
+
+>>>>>>> c206790... Allows downloading of badges in zipped, pdf and svg versions
 @app.route('/upload', methods=['POST'])
 def upload():
-
     filename = "default.png.csv"
     csv = request.form['csv'].strip()
     # If the textbox is filled
@@ -30,7 +37,7 @@ def upload():
         f.close()
     # if user does not select file, browser submits an empty part without filename
     else:
-        file = request.files['file']    
+        file = request.files['file']
         if file.filename == '':
             flash('Please select a CSV file to Upload!', 'error')
             return redirect(url_for('index'))
@@ -55,15 +62,17 @@ def upload():
         if filename != "default.png.csv":
             file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
         generate_badges()
-        flash('Your Badge has been successfully created!', 'success')
+        flash(filename, 'success')
         return redirect(url_for('index'))
     else:
-    	flash('Only CSV file is accepted!', 'error')
-    	return redirect(url_for('index'))
+        flash('Only CSV file is accepted!', 'error')
+        return redirect(url_for('index'))
+
 
 @app.errorhandler(404)
 def Not_Found(e):
-	return render_template('404.html'), 404
+    return render_template('404.html'), 404
+
 
 if __name__ == '__main__':
     app.run()

--- a/app/merge_badges.sh
+++ b/app/merge_badges.sh
@@ -18,7 +18,7 @@ python3 generate-badges.py
 
 echo "Generating PDF files from svg."
 
-for svg in `find | grep -E '\.svg$'`; do
+for svg in `find static/badges/ | grep -E '\.svg$'`; do
   pdf="${svg%.svg}.pdf"
   echo "svg: $svg"
   echo "pdf: $pdf"
@@ -28,13 +28,22 @@ done
 echo "Merging badges of different types."
 
 all=""
-for folder in *.badges; do
+for folder in ./static/badges/*.badges; do
   out="${folder}.pdf"
   echo "merging $folder to $out"
   pdftk "$folder"/*.pdf cat output "$out"
   all="$out $all"
 done
 
-final="all-badges.pdf"
+final="static/badges/all-badges.pdf"
 pdftk $all cat output "$final"
 echo "Created $final"
+
+echo "Generating ZIP file"
+find . \( -iname \*.svg -o -iname \*.pdf \) | zip  -@ all-badges.zip
+
+echo "Generating ZIP of SVG files"
+for folder in $(ls -d */); do
+    filename="${folder%%/}.svg.zip"
+    find ./${folder%%/} -type f -name "*.svg" | zip  -@ $filename
+done

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,12 +5,29 @@
 		<div class="col-md-4 col-md-offset-4">
 			{% with m = get_flashed_messages(with_categories=true) %}
 				{% if m %}
+<<<<<<< HEAD
 					{% for cat,msg in m %}
 						<div class="flash-{{cat}}">{{msg}}</div>
 						{% if cat == 'success' %}
 							<div class="text-center">
-							    <a href="static/uploads/all-badges.pdf" class="btn btn-lg btn-success" download="download">Download as PDF</a>
+							    <a href="static/badges/all-badges.pdf" class="btn btn-lg btn-success" download="download">Download as PDF</a>
 							</div>
+=======
+                    {% for cat,msg in m %}
+                        {% if cat == 'success' %}
+                            <div class="flash-{{cat}}">Your badges has been successfully generated.</div>
+                            <div class="text-center">
+                                <a href="static/uploads/all-badges.zip" class="btn btn-lg btn-success" download="download">Download as ZIP</a>
+                            </div>
+                            <div class="text-center">
+                                <a href="static/uploads/{{msg}}.badges.pdf" class="btn btn-lg btn-success" download="download">Download as PDF</a>
+                            </div>
+                            <div class="text-center">
+                                <a href="static/uploads/{{msg}}.badges.svg.zip" class="btn btn-lg btn-success" download="download">Download as ZIP of SVGs</a>
+                            </div>
+                        {% else %}
+                            <div class="flash-{{cat}}">{{msg}}</div>
+>>>>>>> c206790... Allows downloading of badges in zipped, pdf and svg versions
 					    {% endif %}
 					{% endfor %}
 				{% endif %}
@@ -28,6 +45,6 @@
 				</div>
 		    </form>
 		</div>
-    </div>	
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #37 

#### Short description of what this resolves:
-Code is separated from static files.
-Proper directories arrangement

#### Changes proposed in this pull request:
-Uploads folder now only contains uploaded csv and png files.
-static/badges contain badges formed by uploaded files and also contains all-badges.pdf
-generate-badges.py and merge_badges.sh are now present in app/.
![workspace 1_010](https://user-images.githubusercontent.com/24641089/30329760-dc7398d2-97f0-11e7-8293-243c2300faf8.png)




