### PR TITLE
solves 500 error on missing folder

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,14 +23,18 @@ def generate_badges():
 
 
 def empty_directory():
-    for file in os.listdir(BADGES_FOLDER):
-        file_path = os.path.join(BADGES_FOLDER, file)
-        try:
-            if os.path.isfile(file_path):
-                os.unlink(file_path)
-            elif os.path.isdir(file_path): shutil.rmtree(file_path)
-        except Exception:
-            traceback.print_exc()
+	# checks for badges folder
+	if not os.path.exists(BADGES_FOLDER):
+		os.mkdir(BADGES_FOLDER)	#creates one, if does not exists
+	# emptying previous files and folders inside the badges folder
+	for file in os.listdir(BADGES_FOLDER):
+	    file_path = os.path.join(BADGES_FOLDER, file)
+	    try:
+	        if os.path.isfile(file_path):
+	            os.unlink(file_path)	# removes the file
+	        elif os.path.isdir(file_path): shutil.rmtree(file_path)	# if folder, then remove it completely
+	    except Exception:
+	        traceback.print_exc()
 
 
 @app.route('/upload', methods=['POST'])


### PR DESCRIPTION
added a snippet to check for the badges folder everytime. and make the folder if it does not exists.

Fixes https://github.com/fossasia/badgeyay/issues/58

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->



#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
<!-- If an existing function does not have a docstring, please add one -->
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
It resolves the 500-Internal server error on the application, caused by missing badges folder.

#### Changes proposed in this pull request:

- import-ed `os` module
- check for missing folder
- make the `badges` folder if it does not exists

Thanks ! :D
