### PR TITLE
Menu tests function is divided into three different functions.

### DIFF
--- a/app/tests/test.py
+++ b/app/tests/test.py
@@ -15,12 +15,22 @@ class BadgeyayTest(unittest.TestCase):
 	def test_title(self):
 		self.assertEqual(self.driver.title, 'BadgeYay')
 
-	def test_menu(self):
+	def test_menu_visibility(self):
+		#elem is div element of right most menu bar ,until glyphicon is not clicked it should not
+		#display all menus like (code, bug report etc)
 		elem = self.driver.find_element_by_css_selector(".custom-menu-content")
 		self.assertFalse(elem.is_displayed())
-		self.driver.find_element_by_css_selector(".glyphicon-th").click()
+	
+	def test_menu_click_on(self):
+		#elem is glyphicon element, when it is clicked it should display menu bar containing
+		#(code,bug reports etc)
+		elem=self.driver.find_element_by_css_selector(".glyphicon-th").click()
 		self.assertTrue(elem.is_displayed())
-		self.driver.find_element_by_css_selector(".glyphicon-th").click()
+	
+	def test_menu_click_off(self):
+		#elem is glyphicon element, when it is clicked again it should hide menu bar containing
+		#(code,bug reports etc)		
+		elem=self.driver.find_element_by_css_selector(".glyphicon-th").click()
 		self.assertFalse(elem.is_displayed())
 
 	def test_error(self):


### PR DESCRIPTION

Fixes #91 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] All the functions created/modified in this PR contain relevant docstrings.

#### Short description of what this resolves:
Menu tests function is divided into three functions.


#### Changes proposed in this pull request:

-test_menu() function is divided into three functions. 
-test_menu_visibility,test_menu_click_on,test_menu_click_off are those three divided functions.
-variables are assigned for each finding the element statement
ex:elem=self.driver.find_element_by_css_selector(".glyphicon-th").click()


