### PR TITLE
Fix no argument error for tocsv() call in generate_csv_eventday.py

### DIFF
--- a/app/generate_csv_eventyay.py
+++ b/app/generate_csv_eventyay.py
@@ -5,6 +5,7 @@ except Exception:
     from urllib2 import urlopen
 import json
 import os
+import sys
 
 APP_ROOT = os.path.dirname(os.path.abspath(__file__))
 UPLOAD_FOLDER = os.path.join(APP_ROOT, 'static/uploads')
@@ -53,4 +54,4 @@ def tocsv(url_eventyay, filename):
 
 
 if __name__ == '__main__':
-    tocsv()
+    tocsv(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Relates to #135

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:
- improved code quality in file generate_csv_eventday.py
-  The `No value for argument 'url_eventyay' in function call tocsv()` is resolved by passing system arguments in **tocsv()** . That is, if the generate_csv_eventyay.py is run as a standalone program, the `url_eventyay, filename` would have to be passed as system arguments.


***The following is the Codacy review screenshot for my local fork, after the changes were pushed.***
![135](https://user-images.githubusercontent.com/21140415/31288653-73f51366-aae3-11e7-8acf-a3ac2d68b9a2.png)
