### PR TITLE
Fix #292 - Used cairosvg to generate pdf files

### DIFF
--- a/app/merge_badges.py
+++ b/app/merge_badges.py
@@ -4,6 +4,7 @@ import argparse
 import zipfile
 import subprocess
 from exceptions import PackageNotFoundError
+from cairosvg import svg2pdf
 
 parser = argparse.ArgumentParser(description='Argument Parser for merge_badges')
 parser.add_argument('-p', dest='pdf', action='store_true')
@@ -13,8 +14,6 @@ arguments = parser.parse_args()
 _pdf = arguments.pdf
 _zip = arguments.zip
 
-if subprocess.call(['which', 'rsvg-convert']) != 0:
-    raise PackageNotFoundError("Package rsvg-convert not found")
 if subprocess.call(['which', 'python3']) != 0:
     raise PackageNotFoundError("Package python3 not found")
 if subprocess.call(['which', 'pdftk']) != 0:
@@ -47,8 +46,10 @@ def generate_pdfs(folder_path):
         pdf_path = os.path.splitext(svg_path)[0] + '.pdf'
         print('svg: {}'.format(svg_path))
         print('pdf: {}'.format(pdf_path))
-        subprocess.call(['rsvg-convert', '-f', 'pdf', '-o', pdf_path, svg_path])
-
+        try:
+            svg2pdf(url=svg_path, write_to=pdf_path)
+        except Exception as e:
+            pass
 
 # Generating PDF files from svg.
 if _pdf:


### PR DESCRIPTION
Fixes issue #292, used cairo svg to generate pdf files
instead of rsvg-convert.

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] I have added necessary documentation (if appropriate)
