### PR TITLE
app/merge_badges.py: Replaces pdftk with pypdf

### DIFF
--- a/app/merge_badges.py
+++ b/app/merge_badges.py
@@ -4,6 +4,7 @@ import argparse
 import subprocess
 from exceptions import PackageNotFoundError
 from cairosvg import svg2pdf
+from PyPDF2 import PdfFileMerger
 
 parser = argparse.ArgumentParser(description='Argument Parser for merge_badges')
 parser.add_argument('-p', dest='pdf', action='store_true')
@@ -54,9 +55,20 @@ print('Merging badges of different types.')
 
 for folder in input_folders:
     folder_path = os.path.join(BADGES_FOLDER, folder)
-    out = folder.replace('.', '-') + '.pdf'
+    merger = PdfFileMerger()
+    pdfs = [file for file in os.listdir(folder_path) if file.lower().endswith('.pdf')]
+    for pdf in pdfs:
+        merger.append(open(os.path.join(folder_path, pdf), 'rb'))
+    out = folder + '.pdf'
     out_path = os.path.join(BADGES_FOLDER, out)
-    subprocess.call('pdftk ' + folder_path + '/*.pdf cat output ' + out_path, shell=True)
+    with open(out_path, 'wb') as fout:
+        merger.write(fout)
 
 final_path = os.path.join(BADGES_FOLDER, 'all-badges.pdf')
-subprocess.call('pdftk ' + BADGES_FOLDER + '/*.pdf cat output ' + final_path, shell=True)
+pdfs = [file for file in os.listdir(BADGES_FOLDER) if file.lower().endswith('.pdf')]
+merger = PdfFileMerger()
+for pdf in pdfs:
+    merger.append(open(os.path.join(BADGES_FOLDER, pdf), 'rb'))
+
+with open(final_path, 'wb') as fout:
+    merger.write(fout)


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #380 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:
pdftk which is a non-python library was used to merge pdf files. So
every time to merge pdf files it has to be run as a separate process
via subprocess as it is not a python native library. Replaces it with
pypdf which is a similar library but in python that can be used to merge
pdf files.

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>
