### PR TITLE
Fix virtualenv's "Command not found" bug and fixed broken link for local installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Installation
 --------------
 Badgeyay can be easily deployed on a variety of platforms. Currently it can be deployed in following ways.
 
-1. [Local Installation](/docs/installation/local.md)
+1. [Local Installation](/docs/installation/localvir.md)
 
 2. [Deployment on Heroku](/docs/installation/heroku.md)
 

--- a/docs/installation/localvir.md
+++ b/docs/installation/localvir.md
@@ -29,10 +29,13 @@ $ git remote add upstream https://github.com/fossasia/badgeyay.git
 and [`virtualenvwrapper`](https://virtualenvwrapper.readthedocs.io/en/latest/install.html) to maintain a clean Python 3 environment. Create a `virtualenv`:
 
 ```sh
+$ source `which virtualenvwrapper.sh`
 $ mkvirtualenv -p python3 badgeyay
 (badgeyay) $ deactivate         # To deactivate the virtual environment
 $ workon badgeyay               # To activate it again
 ```
+
+> **source `which virtualenvwrapper.sh`** is used to prevent from breaking the `mkvirtualenv` command, you can find more about the issue, [here](https://stackoverflow.com/questions/13855463/bash-mkvirtualenv-command-not-found).
 
 * Now, since you are inside a virtual environment, you can setup `badgeyay` as an editable package.
 


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #413 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:
![image](https://user-images.githubusercontent.com/5800726/34009160-d30d863c-e12d-11e7-8a19-f60736a1df7c.png)

- Added a bug fix, which threw "Command not found" when executing `mkvirtualenv -p python3 badgeyay`
- Internal Linking and fixing of broken links.
- Reported **Docker** on their universal broken **Docker button** bug found by _**0x48piraj**_ :heart: _(https://twitter.com/0x48piraj/status/941391840766341121)_
