### PR TITLE
Closes #353 : Adds Preview of Badges prior to creation

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -281,3 +281,24 @@ input[type="radio"] {
     vertical-align: middle;
     margin: 0 auto;
 }
+
+.preview-image{
+    height: 250px;
+    width: 180px;
+    margin-left: 80px;
+    background-size: cover;
+    padding: 140px 0 0 5px;
+    text-align: center;
+    margin-top: 20px;
+}
+
+.preview-image-li{
+    list-style: none;
+    color: white;
+    font-size: 15px;
+}
+
+#preview-btn{
+    font-size: 18px;   
+}
+

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -55,4 +55,63 @@ $(document).on("ready", function () {
             $(".version").html("Failed to access version");
         }
     });
+    function readURL(input) {
+
+        if (input.files && input.files[0]) {
+            var reader = new FileReader();
+
+            reader.onload = function (e) {
+                $("#preview").css("background","url(" +  e.target.result + ")");
+                $("#preview").css("background-size","cover");
+                $("#preview-btn").prop("disabled",false);
+            };
+
+            reader.readAsDataURL(input.files[0]);
+        }
+    }
+
+    $("#imageFile").change(function(){
+        readURL(this);
+    });
+
+    $("#picker").change(function(){
+        $("#preview-btn").prop("disabled",false);
+    });
+
+    $("input[name=img-default]").change(function(){
+        $("#preview-btn").prop("disabled",false);
+    });
+
+    $("#preview-btn").on("click",function(e){
+        var imageValue,fontValue;
+        if($("#picker").val() !== ""){
+            imageValue = $("#picker").val();
+            $("#preview").css("background-color",imageValue.toString());
+        }
+        else if($("input[name=img-default]").val() !== ""){
+            imageValue = "/static/uploads/" + $("input[name=img-default]").val();
+            $("#preview").css("background","url(" + imageValue + ")");
+            $("#preview").css("background-size","cover");
+        }
+        if($(".placeholder2")[0].innerText !== "Select a font"){
+            fontValue = $(".placeholder2")[0].innerText;
+            $(".preview-image-li").css("font-family",fontValue.toString());
+        }
+
+        var textValues = $("#textArea").val();
+        textValues = textValues.split("/n")[0].split(",");
+
+
+        $("#preview-li-1").text(textValues[0]);
+        $("#preview-li-2").text(textValues[1]);
+        $("#preview-li-3").text(textValues[2]);
+        $("#preview-li-4").text(textValues[3]);
+
+        $("#preview").toggleClass("hidden");
+        
+    });
+
+    $("#form1").submit(function(e){
+        $("#preview").addClass("hidden");
+    });
 });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %} {% block body %}
 <div class="container board">
     <div class="row">
-        <form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data" onsubmit="return validate()">
+        <form id="form1" action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data" onsubmit="return validate()">
             <div class="row">
                 <div class="container board">
                     <div class="col-md-4 col-md-offset-4 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
@@ -115,7 +115,16 @@
                         </ul>
                         <div id="error" class="config-error"> Please upload a JSON file</div>
                         <button type="submit" disabled="disabled" class="btn btn-block submit-btn">Generate Badges</button>
+						<button type="button" disabled="disabled" class="btn btn-block btn-warning" id="preview-btn">Preview</button>
+                        <div id="preview" class="preview-image hidden">
+                        	<li class="preview-image-li" id="preview-li-1"></li>
+                        	<li class="preview-image-li" id="preview-li-2"></li>
+                        	<li class="preview-image-li" id="preview-li-3"></li>
+                        	<li class="preview-image-li" id="preview-li-4"></li>
+                        </div>
+
                     </div>
+
                 </div>
             </div>
         </form>


### PR DESCRIPTION
User can now have an easy preview by just selecting the background image and typing the field in the CSV box to check how the badge will look.

Closes https://github.com/fossasia/badgeyay/issues/353

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

The actual Badges and the preview badges may be different.
To preview :

* Add the details of one person in the csv box.
* Choose the image you want from any source.
* Click on preview


Deployment Link : http://powerful-bayou-14295.herokuapp.com/

#### Checklist

- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ ] My branch is up-to-date with the Upstream `development` branch.
- [ ] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

-
-
