### PR TITLE
 Allow text-fill option

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ import os
 import json
 import shutil
 import traceback
-from svg_to_png import do_svg2png
+from svg_to_png import do_svg2png, do_text_fill
 
 APP_ROOT = os.path.dirname(os.path.abspath(__file__))
 UPLOAD_FOLDER = os.path.join(APP_ROOT, 'static/uploads')
@@ -81,6 +81,9 @@ def main_task():
     csv = request.form.get('csv', '').strip()
     img = request.form.get('img-default', '')
     custom_font = request.form.get('custfont', '')
+    text_fill = request.form.get('txt_color', '#ffffff')
+
+    do_text_fill(APP_ROOT + "/../badges/8BadgesOnA3.svg", text_fill)
 
     if 'file' in request.files:
         file = request.files['file']

--- a/backend/app/static/js/script.js
+++ b/backend/app/static/js/script.js
@@ -37,7 +37,6 @@ $(document).on("ready", function () {
         theme: 'bootstrap'
     });
 
-
     var apiUrl = "https://api.github.com/repos/fossasia/badgeyay/git/refs/heads/development";
     $.ajax({
         url: apiUrl,

--- a/backend/app/svg_to_png.py
+++ b/backend/app/svg_to_png.py
@@ -6,7 +6,7 @@ import os
 APP_ROOT = os.path.dirname(os.path.abspath(__file__))
 SVGS_FOLDER = os.path.join(APP_ROOT, 'static/svgs')
 UPLOAD_FOLDER = os.path.join(APP_ROOT, 'static/uploads')
-
+ids = ['text4611', 'text4585', 'text4559', 'text4533', 'text4399', 'text4373', 'text4347', 'text4313']
 
 def do_svg2png(filename, opacity, fill):
     """
@@ -36,3 +36,38 @@ def do_svg2png(filename, opacity, fill):
     print("done")
     svg2png(url=filename, write_to=UPLOAD_FOLDER + '/' + png_filename)
     print("Image Saved")
+
+
+def do_text_fill(filename, fill):
+    """
+    Module to change color of badge's details
+    :param `filename` - svg file to modify.
+    :param `fill` - color to be applied on text
+    """
+    tree = etree.parse(open(filename, 'r'))
+    element = tree.getroot()
+    for _id in ids:
+        path = element.xpath(("//*[@id='{}']").format(_id))[0]
+        style_detail = path.get("style")
+        style_detail = style_detail.split(";")
+        if style_detail[7].split(':')[0] == 'fill':
+            style_detail[7] = "fill:" + str(fill)
+            print(style_detail[7])
+        elif style_detail[6].split(':')[0] == 'fill':
+            style_detail[6] = "fill:" + str(fill)
+            print(style_detail[6])
+        else:
+            for ind, i in enumerate(style_detail):
+                if i.split(':')[0] == 'fill':
+                    style_detail[ind] = "fill:" + str(fill)
+        style_detail = ';'.join(style_detail)
+        text_nodes = path.getchildren()
+        path.set("style", style_detail)
+        for t in text_nodes:
+            text_style_detail = t.get("style")
+            text_style_detail = text_style_detail.split(";")
+            text_style_detail[-1] = "fill:" + str(fill)
+            text_style_detail = ";".join(text_style_detail)
+            t.set("style", text_style_detail)
+    etree.ElementTree(element).write(filename, pretty_print=True)
+    print("Text Fill saved!")

--- a/backend/badges/8BadgesOnA3.svg
+++ b/backend/badges/8BadgesOnA3.svg
@@ -118,7 +118,7 @@
          x="1357.12"
          y="1978.5984"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle"
-         id="tspan4609">person_1_line_5 </tspan></text>
+         id="tspan4609">person_1_line_5</tspan></text>
     <text
        id="text4611"
        y="-760.83221"
@@ -150,7 +150,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle;fill:#ffffff"
          y="-604.58221"
          x="854.90674"
-         sodipodi:role="line">person_1_line_5 </tspan></text>
+         sodipodi:role="line">person_1_line_5</tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -199,7 +199,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle"
          y="1978.5984"
          x="993.76929"
-         sodipodi:role="line">person_2_line_5 </tspan></text>
+         sodipodi:role="line">person_2_line_5</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -231,7 +231,7 @@
          x="927.95062"
          y="-601.27728"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle;fill:#ffffff"
-         id="tspan4595">person_2_line_5 </tspan></text>
+         id="tspan4595">person_2_line_5</tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -280,7 +280,7 @@
          x="630.41858"
          y="1978.5984"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle"
-         id="tspan4557">person_3_line_5 </tspan></text>
+         id="tspan4557">person_3_line_5</tspan></text>
     <text
        id="text4559"
        y="-752.23645"
@@ -312,7 +312,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle;fill:#ffffff"
          y="-595.98645"
          x="565.35577"
-         sodipodi:role="line">person_3_line_5 </tspan></text>
+         sodipodi:role="line">person_3_line_5</tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -361,7 +361,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle"
          y="1978.5984"
          x="263.46674"
-         sodipodi:role="line"> person_4_line_5</tspan></text>
+         sodipodi:role="line">person_4_line_5</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -393,7 +393,7 @@
          x="207.18306"
          y="-594.90442"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle;fill:#ffffff"
-         id="tspan4543"> person_4_line_5</tspan></text>
+         id="tspan4543">person_4_line_5</tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -442,7 +442,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle"
          y="1978.5984"
          x="1357.12"
-         sodipodi:role="line">person_5_line_5 </tspan></text>
+         sodipodi:role="line">person_5_line_5</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -474,7 +474,7 @@
          x="-201.08148"
          y="454.50027"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle;fill:#ffffff"
-         id="tspan4409">person_5_line_5 </tspan></text>
+         id="tspan4409">person_5_line_5</tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -523,7 +523,7 @@
          x="993.76929"
          y="1978.5984"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle"
-         id="tspan4371">person_6_line_5 </tspan></text>
+         id="tspan4371">person_6_line_5</tspan></text>
     <text
        id="text4373"
        y="301.05389"
@@ -555,7 +555,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle;fill:#ffffff"
          y="457.30389"
          x="-559.6308"
-         sodipodi:role="line">person_6_line_5 </tspan></text>
+         sodipodi:role="line">person_6_line_5</tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -604,7 +604,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle"
          y="1978.5984"
          x="630.41858"
-         sodipodi:role="line">person_7_line_5 </tspan></text>
+         sodipodi:role="line">person_7_line_5</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -636,7 +636,7 @@
          x="-922.98151"
          y="459.17889"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle;fill:#ffffff"
-         id="tspan4357">person_7_line_5 </tspan></text>
+         id="tspan4357">person_7_line_5</tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -685,7 +685,7 @@
          x="267.06781"
          y="1978.5984"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle"
-         id="tspan4311">person_8_line_5 </tspan></text>
+         id="tspan4311">person_8_line_5</tspan></text>
     <text
        id="text4313"
        y="304.80389"
@@ -717,6 +717,6 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:31.25px;line-height:1.25;font-family:ubuntu;-inkscape-font-specification:ubuntu;text-align:center;text-anchor:middle;fill:#ffffff"
          y="461.05389"
          x="-1286.3323"
-         sodipodi:role="line">person_8_line_5 </tspan></text>
+         sodipodi:role="line">person_8_line_5</tspan></text>
   </g>
 </svg>

--- a/frontend/app/templates/index.hbs
+++ b/frontend/app/templates/index.hbs
@@ -90,7 +90,7 @@
                             </li>
                         </ul>
                         <div id="error" class="no-image-error">Please select a default background or upload an image!</div>
-                        <label>Choose your font</label>
+                        <label>Customize text</label>
                         <ul style="list-style-type:none">
                             <li><input type="radio" name="fontsource" id="custfont">&nbsp;Use Custom font</li>
                             <section id="custom-font" style="display:none">
@@ -109,6 +109,16 @@
                                 </div>
                             </section>
                             <input type="hidden" name="custfont" value="">
+                            <li>
+                            <li>
+                                <input type="radio" name="backsource" id="text-color"> Choose Text Color</li>
+                                <section id="text-fill-input" style="display:none">
+                                    <label for="inputFile"></label>
+                                    <div>
+                                        <input type="text" id="text-picker" class="form-control" name="txt_color">                                     
+                                    </div>
+                                </section>
+                            </li>
                         </ul>
                         <button type="submit" disabled="disabled" class="btn btn-block submit-btn">Generate Badges</button>
                         <button type="button" disabled="disabled" class="btn btn-block btn-warning" id="preview-btn">Preview</button>

--- a/frontend/public/js/form.js
+++ b/frontend/public/js/form.js
@@ -25,6 +25,9 @@ $(document).ready(
             $("#background-input").css("display", "block");
             $("input[name='img-default']").val("user_defined.png");
         });
+        $("#text-color").click(function () {
+            $("#text-fill-input").css("display", "block");
+        });
         $("#custfont").click(function(){
             $("#custom-font").css("display", "block");
         });

--- a/frontend/public/js/script.js
+++ b/frontend/public/js/script.js
@@ -37,6 +37,14 @@ $(document).ready(function () {
         theme: 'bootstrap'
     });
 
+    $("#text-picker").minicolors({
+        control: 'hue',
+        format: 'hex',
+        defaultValue: '#ffffff',
+        letterCase: 'lowercase',
+        position: 'bottom left',
+        theme: 'bootstrap'
+    });
 
     var apiUrl = "https://api.github.com/repos/fossasia/badgeyay/git/refs/heads/development";
     $.ajax({


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #308

#### Checklist

- [ x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ x] My branch is up-to-date with the Upstream `development` branch.
- [ x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

**Preview Link**: https://still-tundra-38583.herokuapp.com/

- Now one can change text color on badges when needed.

![2018-01-26 2](https://user-images.githubusercontent.com/20624380/35437844-3d2cd0c4-02ba-11e8-926e-c0d501d287c3.png)
**Result**:
[user_defined-png-csv-badges (12).pdf](https://github.com/fossasia/badgeyay/files/1667568/user_defined-png-csv-badges.12.pdf)

Without changing text color, default **#ffffff** is set
![2018-01-26 3](https://user-images.githubusercontent.com/20624380/35437894-712be978-02ba-11e8-8b18-507a11ed2517.png)
**Result**:
[user_defined-png-csv-badges (13).pdf](https://github.com/fossasia/badgeyay/files/1667574/user_defined-png-csv-badges.13.pdf)

