### PR TITLE
Add installation steps of heroku on windows.

### DIFF
--- a/backend/docs/installation/heroku.md
+++ b/backend/docs/installation/heroku.md
@@ -9,8 +9,9 @@ One-click Heroku deployment is available:
 * We need to install heroku on our machine. Type the following in your linux terminal:
 	* ```wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh```
   This installs the Heroku Toolbelt on your machine to access heroku from the command line.
+  For windows user, install from [here](https://devcenter.heroku.com/articles/heroku-cli#windows)
 * Next we need to login to our heroku server (assuming that you have already created an account). Type the following in the terminal:
-	* ```heroku login```
+	* ```heroku login``` (for windows user on cygwin or git bash: ```winpty heroku login```)
     * Enter your credentials and login.
 * Once logged in we need to create a space on the heroku server for our application. This is done with the following command
 	* ```heroku create```


### PR DESCRIPTION
For windows, on git bash, `heroku login` don't work, hence use `winpty heroku login`. Refer https://github.com/heroku/cli/issues/84.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #530

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- https://github.com/heroku/cli/issues/84. , windows user will user git bash to commit changes to heroku, not cmd.exe, hence `winpty heroku login` and not `heroku login` should be used.
-
