### PR TITLE
add locationType as hash

### DIFF
--- a/frontend/app/templates/index.hbs
+++ b/frontend/app/templates/index.hbs
@@ -7,7 +7,7 @@
                     <div class="col-md-4 col-md-offset-4 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
                         <label>
                             Choose your Data Source&emsp;
-                            <a id="icon" href="/guide" target="_blank"><i class="fa fa-info-circle"></i></a>
+                            <a id="icon" href="/#/guide" target="_blank"><i class="fa fa-info-circle"></i></a>
                         </label>
                         <ul style="list-style-type:none">
                             <li><input name="datasource" type="radio" id="csvupload">&nbsp;Add CSV file</li>
@@ -27,7 +27,7 @@
                                     </div>
                                     <div id="error" class="csv-error">Please fill data in proper format
                                         <div class="text-center guide">
-                                            <a href="/guide" target="_blank">User Input Guide</a>
+                                            <a href="/#/guide" target="_blank">User Input Guide</a>
                                         </div>
                                     </div>
                                 </section>

--- a/frontend/config/environment.js
+++ b/frontend/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function(environment) {
     modulePrefix: 'badgeyay',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'hash',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #558 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

### Preview Link 
- **Replace XXX with your PR no**
- Link to live demo: http://pr-564-fossasia-badgeyay.surge.sh  

#### Changes proposed in this pull request:
http://badgeyay.com/#/guide exists because when `environment` is `production` in config file, locationType is set to `hash` which is correct. 
hence <a> tag's href should be changes, also for development, locationType when `env` is `development` needed to be switched to `hash` otherwise it is set to `History` using `auto`. 
So locally, now href points to:
![2018-02-02](https://user-images.githubusercontent.com/20624380/35729106-ad5e80f8-0833-11e8-87af-bfc8ddc5ff2d.png)
