### PR TITLE
fix preview margin to align centrally wrt parent element

### DIFF
--- a/frontend/public/css/style.css
+++ b/frontend/public/css/style.css
@@ -290,11 +290,10 @@ input[type="radio"] {
 .preview-image{
     height: 250px;
     width: 180px;
-    margin-left: 80px;
     background-size: cover;
     padding: 140px 0 0 5px;
     text-align: center;
-    margin-top: 20px;
+    margin: 20px auto 0px;
 }
 
 .preview-image-li{


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #572 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

### Preview Link 

- **Replace XXX with your PR no**
- Link to live demo: http://pr-573-fossasia-badgeyay.surge.sh  

#### Changes proposed in this pull request:

- Centrally aligned the preview image, by changing the left, right margin to auto. 
Now its centrally aligned in smaller devices too.