### PR TITLE
Fixes #812 : Support for A3,A4,A5 and A6 badges

### DIFF
--- a/backend/blueprint/api/controllers/generateBadges.py
+++ b/backend/blueprint/api/controllers/generateBadges.py
@@ -30,10 +30,11 @@ def generateBadges():
                 'No Image filename found'))
     csv_name = data.get('csv')
     image_name = data.get('image')
-    text_color = data.get('text-color') or '#ffffff'
+    text_color = data.get('text-color', '#ffffff')
+    badge_size = data.get('badge_size', 'A3')
     svg2png = SVG2PNG()
     svg2png.do_text_fill('static/badges/8BadgesOnA3.svg', text_color)
-    merge_badges = MergeBadges(image_name, csv_name)
+    merge_badges = MergeBadges(image_name, csv_name, badge_size)
     merge_badges.merge_pdfs()
 
     output = os.path.join(app.config.get('BASE_DIR'), 'static', 'temporary', image_name)

--- a/backend/blueprint/api/utils/generate_badges.py
+++ b/backend/blueprint/api/utils/generate_badges.py
@@ -8,12 +8,13 @@ from defusedxml.lxml import _etree as etree
 
 
 class GenerateBadges:
-    def __init__(self, image_name, csv_name):
+    def __init__(self, image_name, csv_name, badge_size):
         self.APP_ROOT = app.config.get('BASE_DIR')
         self.image_name = image_name
         self.image = os.path.join(app.config.get('BASE_DIR'), 'static', 'uploads', 'image', image_name)
         self.csv = os.path.join(app.config.get('BASE_DIR'), 'static', 'uploads', 'csv', csv_name)
-        self.paper_size = 'A3'
+        self.paper_size = {'A3': ['297mm', '420mm'], 'A4': ['210mm', '297mm'], 'A5': ['148mm', '210mm'], 'A6': ['105mm', '148mm']}
+        self.badge_size = badge_size
         self.wrap = True
         self.NUMBER_OF_BADGES_PER_PAGE = 8
         with open(os.path.join(self.APP_ROOT, 'static/badges/8BadgesOnA3.svg'), encoding="UTF-8") as f:
@@ -65,9 +66,8 @@ class GenerateBadges:
         self.configure_badge_page(target)
 
     def configure_badge_page(self, badge_page):
-        if self.paper_size == 'A3':
-            paper_width = '297mm'
-            paper_height = '420mm'
+        paper_width = self.paper_size.get(self.badge_size)[0]
+        paper_height = self.paper_size.get(self.badge_size)[1]
         tree = parse(open(badge_page, 'r'))
         root = tree.getroot()
         path = root.xpath('//*[@id="svg2"]')[0]

--- a/backend/blueprint/api/utils/merge_badges.py
+++ b/backend/blueprint/api/utils/merge_badges.py
@@ -6,9 +6,9 @@ from PyPDF2 import PdfFileMerger
 
 
 class MergeBadges:
-    def __init__(self, image_name, csv_name):
+    def __init__(self, image_name, csv_name, badge_size):
         self.APP_ROOT = app.config.get('BASE_DIR')
-        self.badge_generator = GenerateBadges(image_name, csv_name)
+        self.badge_generator = GenerateBadges(image_name, csv_name, badge_size)
         self.badge_generator.run_generator()
         self.folder = os.path.join(self.APP_ROOT, 'static', 'temporary', os.path.splitext(image_name)[0])
 


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #812 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] I have added necessary documentation (if appropriate)

### Preview Link 

- **Replace XXX with your PR no**
- Link to live demo: http://pr-XXX-fossasia-badgeyay.surge.sh  

#### Changes proposed in this pull request:

- Adds support for the following
- A4
- A3
- A5
- A6

Giving the user the option to choose from 4 sizes. This functionality was not in the previous API.

Cheers!
