### PR TITLE
Fixes #1295 : Abbreviates long names with initials

### DIFF
--- a/api/utils/generate_badges.py
+++ b/api/utils/generate_badges.py
@@ -67,6 +67,12 @@ class GenerateBadges:
 
             for j, text in enumerate(row):
                 text = html.escape(text)
+                if len(text) > 15:
+                    text = text.split()
+                    last = text[-1].capitalize()
+                    text = text[:-1]
+                    initials = ' '.join(list(map(make_initials, text)))
+                    text = initials + ' ' + last
                 content = content.replace(
                     'person_{}_line_{}'.format(i + 1, j + 1), text)
             content = content.replace('badge_{}.png'.format(i + 1), os.path.join(self.folder, 'background.png'))
@@ -83,3 +89,7 @@ class GenerateBadges:
         path.set('width', paper_width)
         path.set('height', paper_height)
         etree.ElementTree(root).write(badge_page, pretty_print=True)
+
+
+def make_initials(val):
+    return val[0].capitalize()


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1295 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [ ] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- Abbreviates long texts with initials

Here is a screenshot where it converts 
- Google Summer of Code 2018 into G S O C 2018
- Ravi Kumar Shankar into R K Shankar

![to_initials](https://user-images.githubusercontent.com/25414121/42693893-3318c12c-86ce-11e8-8942-7267070f6ef1.png)



Cheers!