### PR TITLE
Fixes #1674 : Corrects the alignment of the info buttons

### DIFF
--- a/frontend/app/templates/create-badges.hbs
+++ b/frontend/app/templates/create-badges.hbs
@@ -8,7 +8,7 @@
 <div class="ui stackable mobile reversed grid">
     <div class="{{if previewToggled 'ten' 'sixteen'}} wide column">
         <div class="main-container create-badge segments">
-            <div class="ui segment">
+            <div class="ui clearing segment">
                 <div class="ui form width-container">
                     <div>
                         <div class="ui right aligned grid">
@@ -28,11 +28,11 @@
                     </div>
                 </div>
             </div>
-            <div class="ui segment">
+            <div class="ui  clearing segment">
                 <div class="ui form width-container">
                     <p>
                         <b>Select from one of the Input Sources</b>
-                        <a class="ui icon orange basic button guide" href="{{href-to 'user-guide'}}" data-tooltip="User Input Guide" data-position="right center">
+                        <a class="ui right floated icon orange basic button" href="{{href-to 'user-guide'}}" data-tooltip="User Input Guide" data-position="right center">
                             <i class="info icon"></i>
                         </a>
                     </p>
@@ -51,7 +51,7 @@
                         </div>
                 </div>
             </div>
-                <div class="ui segment">
+                <div class="ui clearing segment">
                     <div class="ui form width-container">
                         <p>
                             <b>Select from one of the Paper Sizes</b>
@@ -67,7 +67,7 @@
                 <div class="ui form width-container">
                     <p>
                         <b>Select from one of the Badge Sizes</b>
-                        <div class="ui icon orange basic button" data-tooltip="Badge size is in inches, 1 inch = 2.54 cm, 1 inch = 25.4 mm" data-position="right center">
+                        <div class="ui right floated icon orange basic button" data-tooltip="Badge size is in inches, 1 inch = 2.54 cm, 1 inch = 25.4 mm" data-position="right center">
                             <i class="info icon"></i>
                         </div>
                     </p>
@@ -78,11 +78,11 @@
                     </div>
                 </div>
             </div>
-            <div class="ui segment">
+            <div class="ui clearing segment">
                 <div class="ui form width-container">
                     <p>
                         <b>Select from one of the background sources</b>
-                        <a class="ui icon orange basic button guide" data-tooltip="Best Suitable Image -> Size(width x height): 749 X 1049px & Resolution: 300 DPI"
+                        <a class="ui right floated icon orange basic button" data-tooltip="Best Suitable Image -> Size(width x height): 749 X 1049px & Resolution: 300 DPI"
                             data-position="right center">
                             <i class="info icon"></i>
                         </a>


### PR DESCRIPTION
The orange info buttons on badgeyay.com/create-badges were incorrectly aligned
,the alignment is being fixed in this issue.

Resolves #1674

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1674 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- Corrects the alignment of the info buttons on the create-badges page
![issue 1674 2](https://user-images.githubusercontent.com/33062425/45426758-bd3f1380-b6ba-11e8-8e66-2aa1c32e19ed.png)
