### PR TITLE
Update Local Development Setup doc

### DIFF
--- a/api/docs/installation/localvir.md
+++ b/api/docs/installation/localvir.md
@@ -67,7 +67,7 @@ $ source badgeyay/bin/activate
 * Install all the requirements.
 
 ```sh
-(badgeyay)$ pip install -r requirements.txt
+(badgeyay)$ pip install -r api/requirements.txt
 ```
 * **Step 2** - Create the database. For that we first open the psql shell. Go to the directory where your postgres file is stored.
 


### PR DESCRIPTION
After activating the virtual environment pip install fails because the requirements file
is inside the api folder

Fixes #1677

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Checklist

- [x ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ x] My branch is up-to-date with the Upstream `development` branch.
- [ x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- feature request

`(badgeyay)$ pip install -r requirements.txt`

Changed to

`(badgeyay)$ pip install -r api/requirements.txt`

