### PR TITLE
Show 6 character limit on password before user can submit the sign-up form

### DIFF
--- a/frontend/app/components/forms/signup-form.js
+++ b/frontend/app/components/forms/signup-form.js
@@ -118,6 +118,17 @@ export default Component.extend({
         }
       });
   },
+  keyUp(event) {
+    if (event.target.name === 'password') {
+      if ((event.target.value).length < 6) {
+        $('#signUpSubmit').attr('disabled', 'true');
+        $('#feedback').html('Your password must have at least 6 characters');
+      } else {
+        $('#signUpSubmit').removeAttr('disabled');
+        $('#feedback').html('');
+      }
+    }
+  },
   keyDown(event) {
     if (event.target.name === 'password') {
       var strongRegex = new RegExp('^(?=.{8,})(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*\\W).*$', 'g');

--- a/frontend/app/styles/partials/signup.scss
+++ b/frontend/app/styles/partials/signup.scss
@@ -48,6 +48,11 @@ $colorwhite: #ffffff;
   }
 }
 
+small {
+  color: red;
+  margin: 0 auto;
+}
+
 meter {
   margin: 0 auto 1em;
   width: 100%;

--- a/frontend/app/templates/components/forms/signup-form.hbs
+++ b/frontend/app/templates/components/forms/signup-form.hbs
@@ -29,6 +29,7 @@
                             </button>
                         </div>
                     </div>
+                    <small id="feedback"></small>
                     <meter  id="password-strength-meter"  value={{level}} ></meter>
                 </div>
                 <div class="field required">
@@ -42,7 +43,7 @@
                         </div>
                     </div>
                     <div class="ui center aligned segment basic">
-                        <button class="ui fluid large submit orange basic button" style="margin-bottom: 10px;" type="submit">
+                        <button disabled id="signUpSubmit" class="ui fluid large submit orange basic button" style="margin-bottom: 10px;" type="submit">
                             Sign Up
                         </button>
                         <div class="ending-border"></div>


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1797 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:
Block the signup/submit button until user enters atleast 6 characters password.
Add `<small>` block to show user the info of 6 characters limit.

![screenshot from 2018-10-18 08-53-29](https://user-images.githubusercontent.com/20624380/47130073-94abca00-d2b5-11e8-904c-0319907482e9.png)

![screenshot from 2018-10-18 08-53-33](https://user-images.githubusercontent.com/20624380/47130071-91b0d980-d2b5-11e8-9754-9c83ba687561.png)
