### PR TITLE
Retrieve user image on login

### DIFF
--- a/frontend/app/torii-adapters/application.js
+++ b/frontend/app/torii-adapters/application.js
@@ -1,8 +1,39 @@
 import Ember from 'ember';
 import ToriiFirebaseAdapter from 'emberfire/torii-adapters/firebase';
+import ENV from '../config/environment';
 
-const { inject } = Ember;
+const { APP } = ENV;
+
+const { inject, RSVP } = Ember;
 
 export default ToriiFirebaseAdapter.extend({
-  firebase: inject.service()
+  firebase: inject.service(),
+
+  /**
+   * Executed after Firebase authentication.
+   *
+   * @param  {Object} authData
+   * @return {Promise<Object>} Updated session info
+   */
+  open(user) {
+    let User = {};
+    Object.keys(user).forEach(key => User[key] = user[key]);
+    return new RSVP.Promise(resolve => {
+      fetch(APP.backLink + '/user/updateLastLogin/' + user.uid)
+        .then(res => res.json())
+        .then(res => {
+          User.photoURL = res.data.attributes.photoURL;
+        })
+        .catch(err => {
+          console.log(err);
+        })
+        .finally(() => {
+          resolve({
+            provider    : this.extractProviderId_(User),
+            uid         : User.uid,
+            currentUser : User
+          });
+        });
+    });
+  }
 });


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1480 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:
The uploaded user image is stored in firebase and its url is also updated in the backend but its not updated in the user profile info in firebase. So when logging in through firebase the user info doesn't contain updated profile picture. I'm not sure if there is a way to update photo url in the user info in firebase, i think its dependent on the provider only (like google profile image or facebook profile image).

I think the best way to deal with this problem is to retrieve photo url from backend during login and change the 'user' object's photoURL value. 

![screenshot from 2018-10-20 23-46-21](https://user-images.githubusercontent.com/21025052/47259078-62bb8300-d4c2-11e8-8913-928d6b7bdac6.png)
