### PR TITLE
correct font color in pdf generated.

### DIFF
--- a/api/utils/svg_to_png.py
+++ b/api/utils/svg_to_png.py
@@ -39,17 +39,17 @@ class SVG2PNG:
                 style_detail = style_detail.split(";")
 
                 if style_detail[7].split(':')[0] == 'fill':
-                    style_detail[7] = "fill:" + str(fill[row])
+                    style_detail[7] = "fill:" + str(fill)
                     print(style_detail[7])
 
                 elif style_detail[6].split(':')[0] == 'fill':
-                    style_detail[6] = "fill:" + str(fill[row])
+                    style_detail[6] = "fill:" + str(fill)
                     print(style_detail[6])
 
                 else:
                     for ind, i in enumerate(style_detail):
                         if i.split(':')[0] == 'fill':
-                            style_detail[ind] = "fill:" + str(fill[row])
+                            style_detail[ind] = "fill:" + str(fill)
                 style_detail = ';'.join(style_detail)
                 text_nodes = path.getchildren()
                 path.set("style", style_detail)
@@ -57,7 +57,9 @@ class SVG2PNG:
                 for t in text_nodes:
                     text_style_detail = t.get("style")
                     text_style_detail = text_style_detail.split(";")
-                    text_style_detail[-1] = "fill:" + str(fill[row])
+                    for ind, i in enumerate(text_style_detail):
+                        if i.split(':')[0] == 'fill':
+                            text_style_detail[ind] = "fill:" + str(fill)
                     text_style_detail = ";".join(text_style_detail)
                     t.set("style", text_style_detail)
 


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1801 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- Since font color / fill/ text_color is input as only a single value, we shouldn't treat it as a list i.e. `fill[row]`.
- Its not necessary `text_style_detail[-1]` is fill property. Locally for me it was `font-family` instead, and thus color is not applied. Rather we should parse the whole style_detail properties to find the `fill` property correctly, and then change it.

![screenshot from 2018-10-24 10-17-11](https://user-images.githubusercontent.com/20624380/47407257-ebaf1480-d777-11e8-97ca-66761455a876.png)

![screenshot from 2018-10-24 10-17-57](https://user-images.githubusercontent.com/20624380/47407240-d33efa00-d777-11e8-9256-2b6aee999113.png)

