### PR TITLE
Generate badges only that are required on a page - save ink!

### DIFF
--- a/api/utils/generate_badges.py
+++ b/api/utils/generate_badges.py
@@ -8,6 +8,15 @@ from defusedxml.lxml import _etree as etree
 from api.utils.dimen import badge_config
 
 
+def remove_extra(badge_page, offset):
+    tree = etree.parse(open(badge_page, 'r'))
+    root = tree.getroot()
+    children = root.findall('.//{http://www.w3.org/2000/svg}g')
+    for i in range(offset, len(children)):
+        children[i].getparent().remove(children[i])
+    etree.ElementTree(root).write(badge_page, pretty_print=True)
+
+
 class GenerateBadges:
     def __init__(self,
                  image_name,
@@ -69,16 +78,8 @@ class GenerateBadges:
             content = content.replace('Pictures/18033231.jpeg', os.path.join(self.folder, 'background.png'))
         with open(target, 'w', encoding='UTF-8') as f:
             f.write(content)
-        self.remove_extra(target, len(rows) + 1)
+        remove_extra(target, len(rows) + 1)
         # self.configure_badge_page(target)
-
-    def remove_extra(self, badge_page, offset):
-        tree = etree.parse(open(badge_page, 'r'))
-        root = tree.getroot()
-        children = root.findall('.//{http://www.w3.org/2000/svg}g')
-        for i in range(offset, len(children)):
-            children[i].getparent().remove(children[i])
-        etree.ElementTree(root).write(badge_page, pretty_print=True)
 
     def configure_badge_page(self, badge_page):
         paper_width = self.paper_size.get(self.paper_dimen)[0]

--- a/api/utils/generate_badges.py
+++ b/api/utils/generate_badges.py
@@ -69,7 +69,16 @@ class GenerateBadges:
             content = content.replace('Pictures/18033231.jpeg', os.path.join(self.folder, 'background.png'))
         with open(target, 'w', encoding='UTF-8') as f:
             f.write(content)
+        self.remove_extra(target, len(rows) + 1)
         # self.configure_badge_page(target)
+
+    def remove_extra(self, badge_page, offset):
+        tree = etree.parse(open(badge_page, 'r'))
+        root = tree.getroot()
+        children = root.findall('.//{http://www.w3.org/2000/svg}g')
+        for i in range(offset, len(children)):
+            children[i].getparent().remove(children[i])
+        etree.ElementTree(root).write(badge_page, pretty_print=True)
 
     def configure_badge_page(self, badge_page):
         paper_width = self.paper_size.get(self.paper_dimen)[0]


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1756 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- Now only number of rows will decide how many badges will be generated on a given paper. Earlier we were generating badges with default content, which is undesirable because of :
*. **Wastage of ink on printing that PDF file (printing useless badges)**

Number of `<g> tags in the svg - rows` decide the not required badges - so **deleted them using ElementTree parsing.**

![screenshot from 2018-10-24 14-42-23](https://user-images.githubusercontent.com/20624380/47420371-e237a380-d79b-11e8-9815-d57418c9cb4e.png)

**Now:**
![screenshot from 2018-10-24 14-42-33](https://user-images.githubusercontent.com/20624380/47420327-c92ef280-d79b-11e8-9372-6e9fced0a7e1.png)

Otherwise above settings would have generated **15 badges**!
