### PR TITLE
Fixed the badge preview interchange

### DIFF
--- a/frontend/app/controllers/create-badges.js
+++ b/frontend/app/controllers/create-badges.js
@@ -560,9 +560,9 @@ export default Controller.extend({
 
     mutateBadgeSize(value) {
       if (value === '4.5x4') {
-        this.set('previewHeight', true);
-      } else {
         this.set('previewHeight', false);
+      } else {
+        this.set('previewHeight', true);
       }
       this.set('badgeSize', value);
     },


### PR DESCRIPTION
Fixes #1980

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

- The 4.5"x4" and 4"x3" preview was interchanged due to wrong values being
passed in the mutateBadgeSize function.

### Screenshots for the change

![screenshot from 2019-01-24 10-49-19](https://user-images.githubusercontent.com/33062425/51656108-c2479400-1fc5-11e9-9ec8-4a0282a4d58c.png)

![screenshot from 2019-01-24 10-49-27](https://user-images.githubusercontent.com/33062425/51656110-c673b180-1fc5-11e9-8742-c497ac0e69fe.png)
