### PR TITLE
Modify ResetPasswordToken in 'Forgot Password'

### DIFF
--- a/api/controllers/resetUser.py
+++ b/api/controllers/resetUser.py
@@ -12,7 +12,7 @@ from api.schemas.errors import (
 )
 from api.schemas.token import TokenSchema
 from api.models.token import ResetPasswordToken
-
+from psycopg2 import ProgrammingError
 
 router = Blueprint('resetUser', __name__)
 
@@ -52,6 +52,11 @@ def pwd_reset_token():
         'id': user.id,
         'exp': expire
     }, app.config.get('SECRET_KEY'))
-    resetObj = ResetPasswordToken(user.id, token.decode('UTF-8'))
+    try:
+        resetObj = ResetPasswordToken.query.get(user.id)
+        resetObj.token = token
+    except ProgrammingError:
+        resetObj = ResetPasswordToken(user.id, token.decode('UTF-8'))
+
     resetObj.save_to_db()
     return jsonify(TokenSchema().dump(resetObj).data)


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #2015 

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.

#### Changes proposed in this pull request:

- When a user sends a request for forgot password, check if ResetPasswordToken for the user already exists, in which case the value of token is overwritten.
- If it does not exist, a new ResetPasswordToken object is generated for that user. 
