### PR TITLE
Fixes #2055: Corrects display of error message

### DIFF
--- a/frontend/app/components/forms/signup-form.js
+++ b/frontend/app/components/forms/signup-form.js
@@ -128,12 +128,14 @@ export default Component.extend({
         $('#feedback').html('');
       }
     }
-    if (document.getElementById('pwd').value == document.getElementById('pwdConfirm').value) {
-      document.getElementById('msg').style.color = 'green';
-      document.getElementById('msg').innerHTML = 'Password match';
-    } else {
-      document.getElementById('msg').style.color = 'red';
-      document.getElementById('msg').innerHTML = 'Passwords do not match';
+    if (event.target.name === 'password' || event.target.id == 'pwdConfirm') {
+      if (document.getElementById('pwd').value == document.getElementById('pwdConfirm').value) {
+        document.getElementById('msg').style.color = 'green';
+        document.getElementById('msg').innerHTML = 'Passwords match';
+      } else {
+        document.getElementById('msg').style.color = 'red';
+        document.getElementById('msg').innerHTML = 'Passwords do not match';
+      }
     }
   },
   keyDown(event) {


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #2055

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] My branch is up-to-date with the Upstream `development` branch.
- [x] I have added necessary documentation (if appropriate)

#### Changes proposed in this pull request:

The error message stating that "Password does'nt match" or success
message stating that it matches appears when the email is entered and
the password field is empty. Fixes it to display the prompt only when
the password filed is not empty.

### Screenshots for the change

![Screenshot from 2019-06-12 22-04-03](https://user-images.githubusercontent.com/8947010/59369704-9c494300-8d5e-11e9-9ac7-72f4addee298.png)
