### PR TITLE
Remove 'npm install' from frontend installation instructions

### DIFF
--- a/docs/frontend/installation/local.md
+++ b/docs/frontend/installation/local.md
@@ -15,7 +15,6 @@ To install the app, run the following commands in a command line:
 
 * `git clone https://github.com/fossasia/badgeyay`
 * `cd badgeyay/frontend`
-* `npm install`
 * `yarn install`
 ## Running locally:
 


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #2144

#### Short description of what this resolves:
Update frontend installation instructions to remove 'npm install'.

#### Changes proposed in this pull request:

- Simply updates the README associated with the frontend installation instructions

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia).
- [X] My branch is up-to-date with the Upstream `development` branch.
- [n/a] The acceptance, integration, unit tests and linter pass locally with my changes <!-- use `ember test` to run all the tests -->
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
